### PR TITLE
Switch back to using wxWidgets critical section

### DIFF
--- a/src/effects/RealtimeEffectState.cpp
+++ b/src/effects/RealtimeEffectState.cpp
@@ -234,6 +234,7 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
                      stateSettings, pMessage.get()
                   };
                   pInstance->RealtimeProcessStart(package);
+                  pInstance->RealtimeProcessEnd(stateSettings);
                   pAccessState->mLastSettings.settings = stateSettings;
                   return;
                }
@@ -261,6 +262,7 @@ struct RealtimeEffectState::Access final : EffectSettingsAccess {
                      stateSettings, pMessage.get()
                   };
                   pInstance->RealtimeProcessStart(package);
+                  pInstance->RealtimeProcessEnd(stateSettings);
                   // Don't need to update pAccessState->mLastSettings
                   return;
                }

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -1241,24 +1241,71 @@ bool VSTEffectInstance::OnePresetWasLoadedWhilePlaying()
    return mPresetLoadedWhilePlaying.exchange(false);
 }
 
+void VSTEffectInstance::DeferChunkApplication()
+{
+   std::lock_guard<std::mutex> guard(mDeferredChunkMutex);
+
+   if (! mChunkToSetAtIdleTime.empty() )
+   {    
+      ApplyChunk(mChunkToSetAtIdleTime);
+      mChunkToSetAtIdleTime.resize(0);
+   }
+}
+
+
+void VSTEffectInstance::ApplyChunk(std::vector<char>& chunk)
+{
+   VstPatchChunkInfo info = {
+      1, mAEffect->uniqueID, mAEffect->version, mAEffect->numParams, "" };
+
+   const auto len = chunk.size();
+   const auto data = chunk.data();
+
+   callSetChunk(true, len, data, &info);
+   for (auto& slave : mSlaves)
+      slave->callSetChunk(true, len, data, &info);
+}
+
+
+bool VSTEffectInstance::ChunkMustBeAppliedInMainThread() const
+{
+   // Some plugins (e.g. Melda) can not have their chunk set in the
+   // audio thread, resulting in making the whole app hang.
+   // This is why we defer the setting of the chunk in the main thread.
+
+   const bool IsAudioThread = (mMainThreadId != std::this_thread::get_id());
+   
+   return IsAudioThread && mIsMeldaPlugin;
+}
+
+
 bool VSTEffectInstance::RealtimeProcessStart(MessagePackage& package)
 {
+   const bool applyChunkInMainThread = ChunkMustBeAppliedInMainThread();
+
+   if (applyChunkInMainThread)
+      mDeferredChunkMutex.lock();
+
    if (!package.pMessage)
       return true;
 
    auto& message = static_cast<VSTEffectMessage&>(*package.pMessage);
 
    auto &chunk = message.mChunk;
-   if (!chunk.empty()) {
-      // Apply the chunk first
 
-      VstPatchChunkInfo info = {
-         1, mAEffect->uniqueID, mAEffect->version, mAEffect->numParams, "" };
-      const auto len = chunk.size();
-      const auto data = chunk.data();
-      callSetChunk(true, len, data, &info);
-      for (auto& slave : mSlaves)
-         slave->callSetChunk(true, len, data, &info);
+   if (!chunk.empty())
+   {
+      if (applyChunkInMainThread)
+      {
+         // Apply the chunk later
+         //
+         mChunkToSetAtIdleTime = chunk;
+      }
+      else
+      {
+         // Apply the chunk now
+         ApplyChunk(chunk);
+      }
 
       // Don't apply the chunk again until another message supplies a chunk
       chunk.resize(0);
@@ -1330,6 +1377,9 @@ size_t VSTEffectInstance::RealtimeProcess(size_t group, EffectSettings &settings
 
 bool VSTEffectInstance::RealtimeProcessEnd(EffectSettings &) noexcept
 {
+   if ( ChunkMustBeAppliedInMainThread() )
+      mDeferredChunkMutex.unlock();
+
    return true;
 }
 
@@ -2295,6 +2345,8 @@ void VSTEffectValidator::OnIdle(wxIdleEvent& evt)
       mLastMovements.clear();
    }
 
+   GetInstance().DeferChunkApplication();
+
    if ( GetInstance().OnePresetWasLoadedWhilePlaying() )
    {
       RefreshParameters();
@@ -2376,7 +2428,8 @@ intptr_t VSTEffectWrapper::callDispatcher(int opcode,
                                    int index, intptr_t value, void *ptr, float opt)
 {
    // Needed since we might be in the dispatcher when the timer pops
-   wxCRIT_SECT_LOCKER(locker, mDispatcherLock);
+   std::lock_guard guard(mDispatcherLock);
+
    return mAEffect->dispatcher(mAEffect, opcode, index, value, ptr, opt);
 }
 
@@ -3956,6 +4009,8 @@ VSTEffectInstance::VSTEffectInstance
       mBlockSize = 8192;
       DoProcessInitialize(44100.0);
    }
+
+   mIsMeldaPlugin = (mVendor == "MeldaProduction");
 }
 
 

--- a/src/effects/VST/VSTEffect.cpp
+++ b/src/effects/VST/VSTEffect.cpp
@@ -2428,8 +2428,7 @@ intptr_t VSTEffectWrapper::callDispatcher(int opcode,
                                    int index, intptr_t value, void *ptr, float opt)
 {
    // Needed since we might be in the dispatcher when the timer pops
-   std::lock_guard guard(mDispatcherLock);
-
+   wxCRIT_SECT_LOCKER(locker, mDispatcherLock);
    return mAEffect->dispatcher(mAEffect, opcode, index, value, ptr, opt);
 }
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -142,7 +142,7 @@ struct VSTEffectWrapper : public VSTEffectLink, public XMLTagHandler, public VST
    intptr_t constCallDispatcher(int opcode, int index,
       intptr_t value, void* ptr, float opt) const;
 
-   wxCRIT_SECT_DECLARE_MEMBER(mDispatcherLock);
+   std::mutex mDispatcherLock;
 
    float callGetParameter(int index) const;
 
@@ -555,6 +555,8 @@ public:
 
    bool OnePresetWasLoadedWhilePlaying();
 
+   void DeferChunkApplication();
+
 private:
 
    void callProcessReplacing(
@@ -573,6 +575,15 @@ private:
    VSTEffectUIWrapper* mpOwningValidator{};
 
    std::atomic_bool mPresetLoadedWhilePlaying{ false };
+
+   std::mutex mDeferredChunkMutex;
+   std::vector<char> mChunkToSetAtIdleTime{};
+
+   void ApplyChunk(std::vector<char>& chunk);
+
+   bool ChunkMustBeAppliedInMainThread() const;
+
+   bool mIsMeldaPlugin{ false };
 };
 
 

--- a/src/effects/VST/VSTEffect.h
+++ b/src/effects/VST/VSTEffect.h
@@ -142,7 +142,7 @@ struct VSTEffectWrapper : public VSTEffectLink, public XMLTagHandler, public VST
    intptr_t constCallDispatcher(int opcode, int index,
       intptr_t value, void* ptr, float opt) const;
 
-   std::mutex mDispatcherLock;
+   wxCRIT_SECT_DECLARE_MEMBER(mDispatcherLock);
 
    float callGetParameter(int index) const;
 


### PR DESCRIPTION
Resolves: #3994 

Honestly, I have no precise explanation why this fix works. The issue happens also with non-melda plugins. Breaking in the debugger when the crash happened did not give useful hints. I can only speculate that std::mutex does not mix well with some other parts of the code which uses wxWidgets critical sections.

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [x] Each commit compiles and runs on my machine without known undesirable changes of behavior
